### PR TITLE
Added support for setting default desktop picture

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,13 @@
+module Helpers
+
+    def self.version
+
+        cmd = Mixlib::ShellOut.new('/usr/bin/sw_vers -productVersion')
+        cmd.run_command
+
+        result = cmd.stdout
+        version ||= result.chomp[/10\.\d+/]
+
+    end
+
+end

--- a/recipes/set_desktop_picture.rb
+++ b/recipes/set_desktop_picture.rb
@@ -1,0 +1,64 @@
+require 'uri'
+
+version  = Helpers.version
+destDir  = File.join(ENV["HOME"], "/Library/Desktop Pictures")
+image    = node['osxdefaults']['desktop_picture']
+
+if image
+
+  isRemote  = ( image =~ /^#{URI::regexp}$/ )
+  extension = ( !isRemote ? File.extname(image) : File.extname(URI.parse(image).path) )[/.+/m] || ".png"
+  destFile  = "#{destDir}/kitchenplan#{extension}"
+
+  unless File.exists?(destFile)
+
+    name = "Set desktop picture"
+
+    # create picture directory
+
+    directory destDir do
+      owner node['current_user']
+      action :create
+    end if !File.directory?(destDir)
+
+    # default arguments
+
+    args = Proc.new {
+
+      path destFile
+
+      if !isRemote
+        content ::File.open(image).read
+      else
+        source image
+      end
+
+      owner node['current_user']
+
+    }
+
+    # save file
+
+    ( isRemote ? remote_file(name, &args) : file(name, &args) )
+
+    if version > "10.8"
+
+      # http://1klb.com/blog/desktop-background-on-os-x-109-mavericks.html
+
+      db  = File.join(ENV["HOME"], "Library/Application\\ Support/Dock/desktoppicture.db")
+      cmd = "\"update data set value = '#{destFile}'\""
+      cmd = "sqlite3 #{db} #{cmd};"
+    else
+
+      # https://gist.github.com/willurd/5829224
+
+      cmd = "defaults write com.apple.desktop Background \"{default = {ImageFilePath='#{destFile}'; };}\""
+    end
+
+    execute "Set default desktop picture"  do
+      command cmd
+    end
+
+  end
+
+end


### PR DESCRIPTION
A users desktop picture can now be set as part of the kitchen plan provision. 

The image can exist on either the local file system or be loaded from a remote url.

```
recipes:
    mac_os_x:
        - osxdefaults::set_desktop_wallpaper
attributes:
    osxdefaults:
        desktop_picture: http://placehold.it/1920x1080&text=kitchen+plan
```

The file will be placed `~/Library/Desktop Pictures/kitchenplan.png`

I also added a helper to allow recipes to have access to the current os version.
