### PR TITLE
fix the add_note_to_loginscreen recipe

### DIFF
--- a/recipes/add_note_to_loginscreen.rb
+++ b/recipes/add_note_to_loginscreen.rb
@@ -1,4 +1,4 @@
 # Do this by hand because the provider does not handle spaces in the value well
 execute "Add a note to the loginscreen - com.apple.loginwindow.plist - LoginwindowText"  do
-    command "defaults write \"com.apple.loginwindow.plist\" \"LoginwindowText\" -string \"#{node['osxdefaults']['loginmessage']}\""
+    command "defaults write \"/Library/Preferences/com.apple.loginwindow.plist\" \"LoginwindowText\" -string \"#{node['osxdefaults']['loginmessage']}\""
 end


### PR DESCRIPTION
The plist needs to be under /Library/Preferences, not the default location

This should fix #9
