### PR TITLE
Add recipe for enabling standard function keys.

### DIFF
--- a/recipes/enable_standard_function_keys.rb
+++ b/recipes/enable_standard_function_keys.rb
@@ -1,0 +1,5 @@
+osxdefaults_defaults "Use all F1, F2, etc. keys as standard function keys" do
+  domain 'NSGlobalDomain'
+  key 'com.apple.keyboard.fnState'
+  boolean true
+end


### PR DESCRIPTION
This recipe has the same effect as checking the box "Use all F1, F2, etc. keys as standard function keys" in the keyboard section of System Preferences.
