### PR TITLE
added recipe for double tap to drag with drag lock

### DIFF
--- a/recipes/trackpad_double_tap_to_drag_with_drag_lock.rb
+++ b/recipes/trackpad_double_tap_to_drag_with_drag_lock.rb
@@ -1,0 +1,11 @@
+osxdefaults_defaults "Double-tap to drag with drag lock 1/2" do
+  domain 'com.apple.driver.AppleBluetoothMultitouch.trackpad'
+  key 'Dragging'
+  boolean true
+end
+
+osxdefaults_defaults "Double-tap to drag with drag lock 2/2" do
+  domain 'com.apple.driver.AppleBluetoothMultitouch.trackpad'
+  key 'DragLock'
+  boolean true
+end


### PR DESCRIPTION
This PR adds a recipe to enable double-tap dragging along with the "Drag Lock" feature. This makes it easier to drag and drop windows/files/etc. with the trackpad.

![screenshot 2014-12-28 16 56 51](https://cloud.githubusercontent.com/assets/1480677/5565082/8ffe56bc-8eb2-11e4-9a75-612874a46fca.png)
