### PR TITLE
Fix tap-to-click in later OSX

### DIFF
--- a/recipes/tap_to_click.rb
+++ b/recipes/tap_to_click.rb
@@ -1,16 +1,22 @@
-osxdefaults_defaults "Tap to click 1/3" do
+osxdefaults_defaults "Tap to click 1/4" do
   domain 'com.apple.driver.AppleBluetoothMultitouch.trackpad'
   key 'Clicking'
   boolean true
 end
 
-osxdefaults_defaults "Tap to click 2/3" do
+osxdefaults_defaults "Tap to click 2/4" do
   domain 'NSGlobalDomain'
   key 'com.apple.mouse.tapBehavior'
   integer 1
 end
 
-osxdefaults_defaults "Tap to click 3/3" do
+osxdefaults_defaults "Tap to click 3/4" do
   domain 'com.apple.mouse.tapBehaviour'
+  integer 1
+end
+
+osxdefaults_defaults "Tap to click 4/4" do
+  domain 'com.apple.AppleMultitouchTrackpad'
+  key 'Clicking'
   integer 1
 end


### PR DESCRIPTION
After running Kitchenplan, tap to click wasn't working so I did some googling and came up with this.